### PR TITLE
Fix Makefile's VERBOSE flag activation in the shell code and lowering deal.ii version requirement down to 9.3.0

### DIFF
--- a/Black-Scholes/Finite-elements/CMakeLists.txt
+++ b/Black-Scholes/Finite-elements/CMakeLists.txt
@@ -13,7 +13,7 @@ SET(TARGET_SRC
 # Minimum resources and versions
 CMAKE_MINIMUM_REQUIRED(VERSION 4.0.1)
 
-FIND_PACKAGE(deal.II 9.6.0
+FIND_PACKAGE(deal.II 9.3.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}
 )
 

--- a/Black-Scholes/Finite-elements/build/run.sh
+++ b/Black-Scholes/Finite-elements/build/run.sh
@@ -3,10 +3,10 @@
 CORES=$(nproc)  # This is the number of cores the computer has, basically this will pararellize the compilation across all cores
 
 # Determines whether or not you want verbose compiler output (flags, debug info, etc.)
-if ["$1" == "1"]; then
+if [$1 == "1"]; then
     VERBOSE_FLAG="VERBOSE=1"
 else
-    VERBOSE_FLAG="VERBOSE=0"
+    VERBOSE_FLAG=""
 fi
 
 # Clean 
@@ -16,6 +16,6 @@ rm CMakeCache.txt
 rm Makefile
 
 # Main compilation and run command
-cmake ..
+cmake .
 make -j$CORES $VERBOSE_FLAG
 ./black-scholes


### PR DESCRIPTION
Issue for the VERBOSE flag was it needs to be empty.
Lowering the deal.II version because it does not require anything above 9.3.0 and system already run on 9.6.0